### PR TITLE
Improve #6.

### DIFF
--- a/DebugLog.all.swift
+++ b/DebugLog.all.swift
@@ -172,7 +172,7 @@ extension CATransform3D : CustomStringConvertible, CustomDebugStringConvertible
 
 import Foundation
 
-struct DebugLog
+public struct DebugLog
 {
     private static let _lock = NSObject()
     
@@ -188,7 +188,7 @@ struct DebugLog
         return self._dateFormatter.stringFromDate(NSDate())
     }
     
-    static var printHandler: (Any!, String, String, Int) -> Void = { body, filename, functionName, line in
+    public static var printHandler: (Any!, String, String, Int) -> Void = { body, filename, functionName, line in
 
         let dateString = DebugLog._currentDateString()
 
@@ -207,7 +207,7 @@ struct DebugLog
         print("\(dateString) [\(filename):\(line)] \(body)")
     }
     
-    static func print(body: Any! = nil, var filename: String = __FILE__, functionName: String = __FUNCTION__, line: Int = __LINE__)
+    public static func print(body: Any! = nil, var filename: String = __FILE__, functionName: String = __FUNCTION__, line: Int = __LINE__)
     {
 #if DEBUG
     

--- a/DebugLog.all.swift
+++ b/DebugLog.all.swift
@@ -172,28 +172,28 @@ extension CATransform3D : CustomStringConvertible, CustomDebugStringConvertible
 
 import Foundation
 
-public struct Config {
-    public static var locale = NSLocale.currentLocale()
-    public static var showDateTime = false
-    public static var dateFormat = "yyyy-MM-dd HH:mm:ss.SSS "
-}
-
 struct DebugLog
 {
-    static let _lock = NSObject()
+    private static let _lock = NSObject()
+    
+    private static let _dateFormatter: NSDateFormatter = {
+        let formatter = NSDateFormatter()
+        formatter.locale = NSLocale.currentLocale()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        return formatter
+    }()
+    
+    private static func _currentDateString() -> String
+    {
+        return self._dateFormatter.stringFromDate(NSDate())
+    }
     
     static var printHandler: (Any!, String, String, Int) -> Void = { body, filename, functionName, line in
 
-        var datetime = ""
-        if Config.showDateTime {
-            let formatter = NSDateFormatter()
-            formatter.locale = Config.locale
-            formatter.dateFormat = Config.dateFormat
-            datetime = formatter.stringFromDate(NSDate())
-        }
+        let dateString = DebugLog._currentDateString()
 
         if body == nil {
-            print("\(datetime)[\(filename).\(functionName):\(line)]")    // print functionName
+            print("\(dateString) [\(filename).\(functionName):\(line)]")    // print functionName
             return
         }
         
@@ -204,7 +204,7 @@ struct DebugLog
             }
         }
         
-        print("\(datetime)[\(filename):\(line)] \(body)")
+        print("\(dateString) [\(filename):\(line)] \(body)")
     }
     
     static func print(body: Any! = nil, var filename: String = __FILE__, functionName: String = __FUNCTION__, line: Int = __LINE__)

--- a/DebugLog/DebugLog.swift
+++ b/DebugLog/DebugLog.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct DebugLog
+public struct DebugLog
 {
     private static let _lock = NSObject()
     
@@ -24,7 +24,7 @@ struct DebugLog
         return self._dateFormatter.stringFromDate(NSDate())
     }
     
-    static var printHandler: (Any!, String, String, Int) -> Void = { body, filename, functionName, line in
+    public static var printHandler: (Any!, String, String, Int) -> Void = { body, filename, functionName, line in
 
         let dateString = DebugLog._currentDateString()
 
@@ -43,7 +43,7 @@ struct DebugLog
         print("\(dateString) [\(filename):\(line)] \(body)")
     }
     
-    static func print(body: Any! = nil, var filename: String = __FILE__, functionName: String = __FUNCTION__, line: Int = __LINE__)
+    public static func print(body: Any! = nil, var filename: String = __FILE__, functionName: String = __FUNCTION__, line: Int = __LINE__)
     {
 #if DEBUG
     

--- a/DebugLog/DebugLog.swift
+++ b/DebugLog/DebugLog.swift
@@ -8,28 +8,28 @@
 
 import Foundation
 
-public struct Config {
-    public static var locale = NSLocale.currentLocale()
-    public static var showDateTime = false
-    public static var dateFormat = "yyyy-MM-dd HH:mm:ss.SSS "
-}
-
 struct DebugLog
 {
-    static let _lock = NSObject()
+    private static let _lock = NSObject()
+    
+    private static let _dateFormatter: NSDateFormatter = {
+        let formatter = NSDateFormatter()
+        formatter.locale = NSLocale.currentLocale()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        return formatter
+    }()
+    
+    private static func _currentDateString() -> String
+    {
+        return self._dateFormatter.stringFromDate(NSDate())
+    }
     
     static var printHandler: (Any!, String, String, Int) -> Void = { body, filename, functionName, line in
 
-        var datetime = ""
-        if Config.showDateTime {
-            let formatter = NSDateFormatter()
-            formatter.locale = Config.locale
-            formatter.dateFormat = Config.dateFormat
-            datetime = formatter.stringFromDate(NSDate())
-        }
+        let dateString = DebugLog._currentDateString()
 
         if body == nil {
-            print("\(datetime)[\(filename).\(functionName):\(line)]")    // print functionName
+            print("\(dateString) [\(filename).\(functionName):\(line)]")    // print functionName
             return
         }
         
@@ -40,7 +40,7 @@ struct DebugLog
             }
         }
         
-        print("\(datetime)[\(filename):\(line)] \(body)")
+        print("\(dateString) [\(filename):\(line)] \(body)")
     }
     
     static func print(body: Any! = nil, var filename: String = __FILE__, functionName: String = __FUNCTION__, line: Int = __LINE__)

--- a/Demo/DebugLogDemoTests/DebugLogDemoTests.swift
+++ b/Demo/DebugLogDemoTests/DebugLogDemoTests.swift
@@ -143,22 +143,6 @@ class DebugLogTests: XCTestCase
         testAsync()
         LOG("")
     }
-
-    func testDatetimeConfig() {
-        LOG(); LOG(1); LOG(NSObject())
-        let (showDateTime, locale, dateFormat) = (Config.showDateTime, Config.locale, Config.dateFormat)
-        Config.showDateTime = true
-        Config.locale = NSLocale(localeIdentifier: "ja_JP")
-        Config.dateFormat = "yyyy/MM/dd hh-mm-ss-SSS z"
-        LOG(); LOG(1); LOG(NSObject())
-        Config.locale = NSLocale(localeIdentifier: "__invalid__")
-        LOG(); LOG(1); LOG(NSObject())
-        // restore
-        Config.showDateTime = showDateTime
-        Config.locale = locale
-        Config.dateFormat = dateFormat
-        LOG(); LOG(1); LOG(NSObject())
-    }
     
     func testPrintlnPerformance()
     {


### PR DESCRIPTION
This is an improvement for #6 datetime printing support by default.

Please also note that `Debug.printHandler` is always customizable to any format & logging destination.
