### PR TITLE
Use LOG instead of LOG_OBJECT when DDFileReader fails to open the file.

### DIFF
--- a/DebugLog.all.swift
+++ b/DebugLog.all.swift
@@ -251,6 +251,8 @@ public func LOG_OBJECT(body: Any, filename: String = __FILE__, functionName: Str
         let logBody = "\(reader.readLogLine(line)) = \(body)"
         
         LOG(logBody, filename: filename, functionName: functionName, line: line)
+    } else {
+        LOG(body, filename: filename, functionName: functionName, line: line)
     }
     
 #endif

--- a/DebugLog/DebugLog.swift
+++ b/DebugLog/DebugLog.swift
@@ -87,6 +87,8 @@ public func LOG_OBJECT(body: Any, filename: String = __FILE__, functionName: Str
         let logBody = "\(reader.readLogLine(line)) = \(body)"
         
         LOG(logBody, filename: filename, functionName: functionName, line: line)
+    } else {
+        LOG(body, filename: filename, functionName: functionName, line: line)
     }
     
 #endif

--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ will display:
 2015-12-12 18:01:00.383 [AppDelegate:44] nsRange = (2,4)
 2015-12-12 18:01:00.384 [AppDelegate:47] optional = nil
 ```
+Note
+----------
+`LOG_OBJECT` does not print variable names on Devices. Output would look like this.
+
+  ```
+  2015-12-12 18:01:00.375 [AppDelegate.application(_:didFinishLaunchingWithOptions:):24]
+  2015-12-12 18:01:00.376 [AppDelegate:26] Hello World!
+  2015-12-12 18:01:00.380 [AppDelegate:28] nil
+  2015-12-12 18:01:00.381 [AppDelegate:29] DebugLogDemo.AppDelegate
+  2015-12-12 18:01:00.381 [AppDelegate:32] 3
+  2015-12-12 18:01:00.382 [AppDelegate:35] 3.0
+  2015-12-12 18:01:00.382 [AppDelegate:38] (10.0, 20.0, 30.0, 40.0)
+  2015-12-12 18:01:00.383 [AppDelegate:41] 1..<4
+  2015-12-12 18:01:00.383 [AppDelegate:44] (2,4)
+  2015-12-12 18:01:00.384 [AppDelegate:47] nil
+  ```
 
 For further customization, change default `Debug.printHandler` to print in any format & logging destination.
 


### PR DESCRIPTION
Fixes https://github.com/inamiy/DebugLog/issues/10
